### PR TITLE
i was left out of file name in example

### DIFF
--- a/_episodes/02-counting-mining.md
+++ b/_episodes/02-counting-mining.md
@@ -531,7 +531,7 @@ $ wc -l results/*.tsv
 {: .bash}
 ~~~
    10695 2016-07-19_JAi-revolution.tsv
-    7859 2016-07-19_JAw-revolution.tsv
+    7859 2016-07-19_JAiw-revolution.tsv
    18554 total
 ~~~
 {: .output}


### PR DESCRIPTION
The file is created above as 2016-07-19_JAiw-revolution.tsv, but the results say 2016-07-19_JAw-revolution.tsv in the example.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
