### PR TITLE
should be commands not command

### DIFF
--- a/_episodes/02-counting-mining.md
+++ b/_episodes/02-counting-mining.md
@@ -17,7 +17,7 @@ objectives:
 keypoints:
 - "The shell can be used to count elements of documents"
 - "The shell can be used to search for patterns within files"
-- "Command can be used to count and mine any number of files"
+- "Commands can be used to count and mine any number of files"
 - "Commands and flags can be combined to build complex queries specific to your work"
 
 ---


### PR DESCRIPTION
The 's' is missing off commands here,

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
