### PR TITLE
T left off of different

### DIFF
--- a/_episodes/02-counting-mining.md
+++ b/_episodes/02-counting-mining.md
@@ -137,7 +137,7 @@ $ wc -l *.tsv
 {: .output}
 
 The `wc` command itself doesn't have a flag to sort the output, but as we'll
-see, we can combine three differen shell commands to get what we want.
+see, we can combine three different shell commands to get what we want.
 
 First, we have the `wc -l *.tsv` command. We will save the output from this
 command in a new file. To do that, we *redirect* the output from the command


### PR DESCRIPTION
The t was left of the word different.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
